### PR TITLE
Bury menu take turn refactor

### DIFF
--- a/Game.py
+++ b/Game.py
@@ -33,28 +33,12 @@ class Game:
             b.neighbors[RIGHT] = c
 
     def _deal_cards(self, age: int):
-        card_list = self.__get_cards_for_age(age)
+        card_list = self._get_cards_for_age(age)
         random.shuffle(card_list)
         for i, player in enumerate(self.players):
             player.hand = card_list[i * 7: (i + 1) * 7]
 
-    def _play_round(self, age: int):
-        self._deal_cards(age)
-        for i in range(6):
-            print(f"begin round: {i}")
-            for player_number, player in enumerate(self.players):
-                print(f"{player.name}'s turn")
-                print(f"your hand is:\n{player.hand_to_str()}")
-                print(f"Bury cost: {min_cost(player.get_payment_options(player.wonder.get_next_power()))}")
-
-                player_input = input("(p)lay, (d)iscard or (b)ury a card: ")
-                action, card_index = player_input[0], int(player_input[1])
-
-                player.take_action(action, card_index)
-            self._pass_hands(age)
-        # todo calculate victory points
-
-    def __get_cards_for_age(self, age: int) -> List[Card]:
+    def _get_cards_for_age(self, age: int) -> List[Card]:
         return [card for card in self.cards if card.age == age]
 
     def _get_player(self, player_number: int) -> Player:

--- a/Game.py
+++ b/Game.py
@@ -60,18 +60,34 @@ class Game:
     def _get_player(self, player_number: int) -> Player:
         return self.players[player_number]
 
-    def _pass_hands(self, age: int):
+    def _pass_hands(self, direction: str):
         player_order = self.players + [self.players[0]]
-
-        if self.pass_order[age] == LEFT:
+        if direction == LEFT:
             player_order.reverse()
-
         temp_hand = []
         for player in player_order:
             player.hand, temp_hand = temp_hand, player.hand
+
+    def _end_round(self, age: int):
+        self._pass_hands(self.pass_order[age])
+
+    def _end_age(self):
+        pass
+
+    def _end_game(self):
+        pass  # todo calculate victory points
 
     def play(self):
         print("starting game!")
         for age in range(1, 4):
             print(f"begin age: {age}")
-            self._play_round(age)
+            self._deal_cards(age)
+            for round_number in range(6):
+                print(f"begin round: {round_number}")
+                for player_number, player in enumerate(self.players):
+                    print(f"{player.name}'s turn")
+                    player.take_turn()
+                self._end_round(age)
+            self._end_age()
+        self._end_game()
+

--- a/Game.py
+++ b/Game.py
@@ -1,9 +1,11 @@
+from typing import Dict
+
 from Player import Player
 from util import *
 
 
 class Game:
-    pass_order = {
+    pass_order: Dict[int, str] = {
         1: LEFT,
         2: RIGHT,
         3: LEFT
@@ -21,7 +23,7 @@ class Game:
         self.players = [Player(str(i), wonder) for i, wonder in enumerate(random.sample(ALL_WONDERS, num_players))]
         self._set_neighbors()
 
-        [print(p) for p in self.players]
+        [print(p) for p in self.players]  # todo debug logging (remove this?)
 
         print("game created")
 
@@ -31,9 +33,8 @@ class Game:
             b.neighbors[RIGHT] = c
 
     def _deal_cards(self, age: int):
-        card_list = self._get_cards(age)
+        card_list = self.__get_cards_for_age(age)
         random.shuffle(card_list)
-
         for i, player in enumerate(self.players):
             player.hand = card_list[i * 7: (i + 1) * 7]
 
@@ -53,7 +54,7 @@ class Game:
             self._pass_hands(age)
         # todo calculate victory points
 
-    def _get_cards(self, age: int) -> List[Card]:
+    def __get_cards_for_age(self, age: int) -> List[Card]:
         return [card for card in self.cards if card.age == age]
 
     def _get_player(self, player_number: int) -> Player:

--- a/Game.py
+++ b/Game.py
@@ -86,7 +86,9 @@ class Game:
                 print(f"begin round: {round_number}")
                 for player_number, player in enumerate(self.players):
                     print(f"{player.name}'s turn")
-                    player.take_turn()
+                    turn_over = False
+                    while not turn_over:
+                        turn_over = player.take_turn()
                 self._end_round(age)
             self._end_age()
         self._end_game()

--- a/Player.py
+++ b/Player.py
@@ -61,9 +61,9 @@ class Player:
     def _bury(self, card: Card):
         print(f"burying {card.name}")
         wonder_power = self.wonder.get_next_power()
-        self._activate_card(wonder_power)
+        self._play_card(wonder_power)
 
-    def _activate_card(self, card: Card):
+    def _play_card(self, card: Card):
         print(card)
         payment_options = self.get_payment_options(card)
         self._display_payment_options(payment_options)
@@ -95,21 +95,10 @@ class Player:
             pass  # todo
 
     def get_victory(self):
-        # military, treasury//3, wonder state, civilian structures, commercial effects, science
+        # todo military, treasury//3, wonder state, civilian structures, commercial effects, science
         vp = 0
         vp += self.board["military_points"]
         vp += self.board["coins"] // 3
-        
         for effects in self.effects["victory"]:
             vp += effects.resources[0][1]
-        
-    
         return vp
-
-        
-
-
-
-
-
-    

--- a/Player.py
+++ b/Player.py
@@ -1,5 +1,5 @@
 from collections import Counter
-from typing import Dict
+from typing import Dict, Set
 
 from util import *
 
@@ -18,7 +18,7 @@ class Player:
         "science": 0,
         "guild": 0
     }
-    coupons = set()
+    coupons: Set[Card] = set()
     effects: Dict[str, List[Effect]] = {}
     neighbors: Dict[str, 'Player'] = {
         LEFT: None,

--- a/Player.py
+++ b/Player.py
@@ -48,31 +48,43 @@ class Player:
         return '\n'.join(f"({i}) {str(card)} | Cost: {min_cost(self._get_payment_options(card))}"
                          for i, card in enumerate(self.hand))
 
-    def _take_action(self, action: str, card_index: int = None):
-        card = self.hand.pop(card_index)
-        if action == 'p':
-            self._play(card)
-        elif action == 'd':
-            self._discard(card)
-        elif action == 'b':
-            self._bury(card)
-        else:
-            raise Exception("we currently don't handle invalid actions!")  # todo
+    def _menu(self) -> bool:
+        print("menu")
+        return False
 
-    def _play(self, card: Card):
+    def _take_action(self, action: str, card_index: int = None) -> bool:
+        if action == 'm':
+            return self._menu()
+        card = self.hand[card_index]
+        if action == 'p':
+            return self._play(card)
+        elif action == 'd':
+            return self._discard(card)
+        elif action == 'b':
+            return self._bury(card)
+        else:
+            print(f"Invalid action! {action}")
+            return False
+
+    def _play(self, card: Card) -> bool:
         print(f"playing {card}")
         # todo do any action at all
+        return True
 
-    def _discard(self, card: Card):
+    def _discard(self, card: Card) -> bool:
         print(f"discarding {card}")
         self.board['coins'] += 3
+        return True
 
-    def _bury(self, card: Card):
+    def _bury(self, card: Card) -> bool:
         print(f"burying {card.name}")
         wonder_power = self.wonder.get_next_power()
-        self._play_card(wonder_power)
+        successfully_played = self._play_card(wonder_power)
+        if successfully_played:
+            self.hand.remove(card)
+        return successfully_played
 
-    def _play_card(self, card: Card):
+    def _play_card(self, card: Card) -> bool:
         print(card)
         payment_options = self._get_payment_options(card)
         self._display_payment_options(payment_options)
@@ -80,6 +92,7 @@ class Player:
         selected_option = payment_options[player_input]
         # todo increment neighbors coins, and decrement own coins
         # todo activate effects of card
+        return True
 
     def _display_payment_options(self, payment_options):
         print("Payment options:")

--- a/Player.py
+++ b/Player.py
@@ -35,11 +35,20 @@ class Player:
                f"board = {self.board}, " \
                f"hand = {self.hand}, "
 
-    def hand_to_str(self) -> str:
-        return '\n'.join(f"({i}) {str(card)} | Cost: {min_cost(self.get_payment_options(card))}"
+    def take_turn(self) -> bool:
+        print(f"your hand is:\n{self._hand_to_str()}")
+        print(f"Bury cost: {min_cost(self._get_payment_options(self.wonder.get_next_power()))}")
+        player_input = list(input("(p)lay, (d)iscard or (b)ury a card: ").replace(' ', ''))
+        action = player_input[0]
+        if len(player_input) > 1:
+            return self._take_action(action, int(player_input[1]))
+        return self._take_action(action)
+
+    def _hand_to_str(self) -> str:
+        return '\n'.join(f"({i}) {str(card)} | Cost: {min_cost(self._get_payment_options(card))}"
                          for i, card in enumerate(self.hand))
 
-    def take_action(self, action: str, card_index: int):
+    def _take_action(self, action: str, card_index: int = None):
         card = self.hand.pop(card_index)
         if action == 'p':
             self._play(card)
@@ -65,7 +74,7 @@ class Player:
 
     def _play_card(self, card: Card):
         print(card)
-        payment_options = self.get_payment_options(card)
+        payment_options = self._get_payment_options(card)
         self._display_payment_options(payment_options)
         player_input = int(input("select a payment option: "))
         selected_option = payment_options[player_input]
@@ -77,7 +86,7 @@ class Player:
         for i, option in enumerate(payment_options):
             print(f"({i}) {self.neighbors[LEFT].name} -> {option[0]}, {self.neighbors[RIGHT].name} -> {option[1]}")
 
-    def get_payment_options(self, card: Card) -> List[Tuple[int, int]]:
+    def _get_payment_options(self, card: Card) -> List[Tuple[int, int]]:
         return [(1, 0)]
 
         for resource, count in Counter(card.cost).items():

--- a/Wonder.py
+++ b/Wonder.py
@@ -18,5 +18,9 @@ class Wonder:
                f"powers = {self.powers}, " \
                f"level = {self.level}"
 
-    def get_next_power(self) -> Card:
-        return self.powers[self.level]
+    def get_next_power(self) -> Card:  # todo we should check to make sure we can't bury if level exceeded
+        return self.powers[self.level]  # todo this will throw an exception at max level
+
+    def increment_level(self):  # todo we can check if this is incremented too much
+        self.level += 1
+

--- a/util.py
+++ b/util.py
@@ -64,7 +64,19 @@ def get_all_cards(num_players: int) -> List[Card]:
 
 
 def min_cost(payment_options) -> int:
-    return min(a + b for a, b in payment_options)
+    return min(total_payment(payment) for payment in payment_options)
+
+
+def total_payment(payment: Tuple[int, int]):
+    return left_payment(payment) + right_payment(payment)
+
+
+def left_payment(payment: Tuple[int, int]):
+    return payment[0]
+
+
+def right_payment(payment: Tuple[int, int]):
+    return payment[1]
 
 
 ALL_WONDERS = all_wonders()


### PR DESCRIPTION
moving the entire game 'loop' into Game::play() for readability, extracting the meat of the play logic into Player::take_turn

we'll keep taking the same player turn, if take_turn returns False to support retries (i.e invalid actions, opening the menu (will be fleshed out later to support displaying info, i.e player info, game info), or canceling actions)

implemented bury,
we'll pop the card only after a successful card play, as opposed to right upon trying to play the card to support failed card plays