### PR TITLE
expand the game state update to include opponent data

### DIFF
--- a/bot/CheapPlayer.py
+++ b/bot/CheapPlayer.py
@@ -9,6 +9,7 @@ class CheapPlayer(BasePlayer):
         payment_option = 0
         index = 0
         payment_cost = 999  # big number to start
+        own_data = self.game_state["self"]
         for card, cost in cards.items():
             min_cost = min((sum(payment) for payment in cost), default=999)
             if min_cost < payment_cost:
@@ -16,8 +17,8 @@ class CheapPlayer(BasePlayer):
                     if sum(cost[i]) < payment_option:
                         payment_option = i
                 payment_cost = min_cost
-                index = self.game_state["hand"].index(str(card))
-        if payment_cost > self.game_state["coins"]:
+                index = own_data["hand"].index(str(card))
+        if payment_cost > own_data["tokens"]["coins"]:
             return "d0"
         else:
             response = "p" + str(index)

--- a/bot/RandomPlayer.py
+++ b/bot/RandomPlayer.py
@@ -6,7 +6,7 @@ from bot.BasePlayer import BasePlayer
 class RandomPlayer(BasePlayer):
     def _handle_input(self, data: dict) -> str:
         return random.choice(data["options"]) + str(
-            random.randrange(0, len(self.game_state["hand"]))
+            random.randrange(0, len(self.game_state["self"]["hand"]))
         )
 
     def _handle_payment(self, data: dict) -> str:


### PR DESCRIPTION
I would like to augment the capablities of the bot players, this first requires that the bots get access to more data about the game state.

to start, let's update the bot with the opponents played cards, and the opponents tableu data.

i believe that after each opponent's hand has been seen once, we should be able to track that hand as it moves across the table. however, i believe it will be best to wait until later to add that functionality in the name of a simpler preliminary change.